### PR TITLE
#217 - Grid format images displayed below and behind grid boxes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -204,3 +204,23 @@
 .gd-selection-selector-item.nextsection {
     justify-content: flex-end;
 }
+.grid-section .card-header {
+    min-height: 50px;
+    max-height: 80px;
+    overflow: hidden;
+    flex-direction: column;
+    display: flex;
+}
+
+.grid-image-container {
+    flex-grow: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.grid-image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}

--- a/styles.css
+++ b/styles.css
@@ -171,6 +171,11 @@
     text-align: center;
 }
 
+.format-grid .card-header.text-truncate h3{
+    white-space: normal;
+    word-wrap: break-word;
+}
+
 /* Single section navigation */
 .course-content .single-section .section-navigation.gd-selection-selector-container {
     align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -174,6 +174,12 @@
 .format-grid .card-header.text-truncate h3{
     white-space: normal;
     word-wrap: break-word;
+    font-size: 1.2rem;
+    margin-bottom: 0px;
+}
+.format-grid .card-header.text-truncate {
+    padding-left: 15px;
+    padding-right: 15px;
 }
 
 /* Single section navigation */

--- a/styles.css
+++ b/styles.css
@@ -74,13 +74,13 @@
 }
 
 .format-grid .thegrid .grid-image {
-    height: 140px;
+    height: 100%!important;
     position: relative;
 }
 
 .format-grid .thegrid .grid-generatedimage {
     background-size: contain;
-    height: 140px;
+    height:  100%!important;
 }
 
 /*rtl:begin:ignore*/
@@ -171,11 +171,17 @@
     text-align: center;
 }
 
-.format-grid .card-header.text-truncate h3{
+.card-header.text-truncate h3 {
     white-space: normal;
     word-wrap: break-word;
     font-size: 1.2rem;
     margin-bottom: 0px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2; /* Limits text to two lines */
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-height: 3.6em; /* This sets the maximum height for two lines, adjust depending on your font-size */
 }
 .format-grid .card-header.text-truncate {
     padding-left: 15px;
@@ -217,10 +223,14 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 100%; /* Ensures full width */
+    height: 140px; /* Set a consistent height */
+    max-width: 100%;
 }
 
 .grid-image {
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
+    width: 100%; /* Ensure the image takes up full width of the container */
+    height: 100%; /* Ensure the image takes up full height of the container */
+    object-fit: cover; /* Ensures the image covers the container without distortion */
+    object-position: center; /* Center the image within the container */
 }

--- a/styles.css
+++ b/styles.css
@@ -211,8 +211,8 @@
     justify-content: flex-end;
 }
 .grid-section .card-header {
-    min-height: 50px;
-    max-height: 80px;
+    min-height: 87px;
+    max-height: 87px;
     overflow: hidden;
     flex-direction: column;
     display: flex;
@@ -223,14 +223,14 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 100%; /* Ensures full width */
-    height: 140px; /* Set a consistent height */
+    width: 100%; 
+    height: 140px; 
     max-width: 100%;
 }
 
 .grid-image {
-    width: 100%; /* Ensure the image takes up full width of the container */
-    height: 100%; /* Ensure the image takes up full height of the container */
-    object-fit: cover; /* Ensures the image covers the container without distortion */
-    object-position: center; /* Center the image within the container */
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
 }

--- a/templates/grid.mustache
+++ b/templates/grid.mustache
@@ -75,8 +75,12 @@
     {{/sectionbreak}}
     <div id="section-{{number}}" class="grid-section card{{#iscurrent}} currentgridsection{{/iscurrent}}" title="{{sectionname}}">
         {{^popup}}
-        {{#hasbadge}}<div class="grid-section-inner">{{/hasbadge}}
-        {{^hasbadge}}<a class="grid-section-inner" href="{{sectionurl}}">{{/hasbadge}}
+        {{#hasbadge}}
+        <div class="grid-section-inner">
+        {{/hasbadge}}
+        {{^hasbadge}}
+        <a class="grid-section-inner" href="{{sectionurl}}">
+        {{/hasbadge}}
         {{/popup}}
         {{#popup}}
         <div class="grid-modal grid-section-inner d-flex flex-column h-100 justify-content-between" data-toggle="modal" data-target="#gridPopup" data-section="{{number}}" tabindex="0">
@@ -109,12 +113,19 @@
             </div>
             {{/imageerror}}
         {{^popup}}
-        {{#notavailable}}</div>{{/notavailable}}
-        {{^notavailable}}</a>{{/notavailable}}
+        {{#notavailable}}
+        </div>
+        {{/notavailable}}
+        {{^notavailable}}
+        </a>
+        {{/notavailable}}
         {{/popup}}
         {{#popup}}
         </div>
         {{/popup}}
+        {{#hasbadge}}
+        </div>
+        {{/hasbadge}}
     </div>
     {{/gridsections}}
 </div>

--- a/templates/grid.mustache
+++ b/templates/grid.mustache
@@ -75,8 +75,8 @@
     {{/sectionbreak}}
     <div id="section-{{number}}" class="grid-section card{{#iscurrent}} currentgridsection{{/iscurrent}}" title="{{sectionname}}">
         {{^popup}}
-        {{#hasbadge}}<div class="grid-section-inner">{{/hasbadge}}
-        {{^hasbadge}}<a class="grid-section-inner" href="{{sectionurl}}">{{/hasbadge}}
+        {{#hasbadge}}<div class="grid-section-inner d-flex flex-column h-100">{{/hasbadge}}
+        {{^hasbadge}}<a class="grid-section-inner d-flex flex-column h-100" href="{{sectionurl}}">{{/hasbadge}}
         {{/popup}}
         {{#popup}}
         <div class="grid-modal grid-section-inner d-flex flex-column h-100 justify-content-between" data-toggle="modal" data-target="#gridPopup" data-section="{{number}}" tabindex="0">
@@ -91,23 +91,22 @@
                 </div>
                 {{/hasbadge}}
             </div>
-            {{#imageuri}}
-            <div class="grid-image card-img-bottom text-center">
-                <img src="{{imageuri}}" alt="{{imagealttext}}" loading="lazy">
+            <div class="grid-image-container flex-grow-1 d-flex align-items-center justify-content-center">
+                {{#imageuri}}
+                <img src="{{imageuri}}" alt="{{imagealttext}}" loading="lazy" class="grid-image">
                 {{#sectioncompletionmarkup}}{{{sectioncompletionmarkup}}}{{/sectioncompletionmarkup}}
+                {{/imageuri}}
+                {{#generatedimageuri}}
+                <div class="grid-generatedimage" style="background-image: url('{{generatedimageuri}}');">
+                </div>
+                {{/generatedimageuri}}
+                {{#imageerror}}
+                <div class="grid-image-error card-img-bottom text-center">
+                    <p><small>{{imageerror}}</small></p>
+                    {{#sectioncompletionmarkup}}{{{sectioncompletionmarkup}}}{{/sectioncompletionmarkup}}
+                </div>
+                {{/imageerror}}
             </div>
-            {{/imageuri}}
-            {{#generatedimageuri}}
-            <div class="grid-generatedimage card-img-bottom text-center" style="background-image: url('{{generatedimageuri}}');">
-                {{#sectioncompletionmarkup}}{{{sectioncompletionmarkup}}}{{/sectioncompletionmarkup}}
-            </div>
-            {{/generatedimageuri}}
-            {{#imageerror}}
-            <div class="grid-image-error card-img-bottom text-center">
-                <p><small>{{imageerror}}</small></p>
-                {{#sectioncompletionmarkup}}{{{sectioncompletionmarkup}}}{{/sectioncompletionmarkup}}
-            </div>
-            {{/imageerror}}
         {{^popup}}
         {{#hasbadge}}</div>{{/hasbadge}}
         {{^hasbadge}}</a>{{/hasbadge}}

--- a/templates/grid.mustache
+++ b/templates/grid.mustache
@@ -75,12 +75,8 @@
     {{/sectionbreak}}
     <div id="section-{{number}}" class="grid-section card{{#iscurrent}} currentgridsection{{/iscurrent}}" title="{{sectionname}}">
         {{^popup}}
-        {{#hasbadge}}
-        <div class="grid-section-inner">
-        {{/hasbadge}}
-        {{^hasbadge}}
-        <a class="grid-section-inner" href="{{sectionurl}}">
-        {{/hasbadge}}
+        {{#hasbadge}}<div class="grid-section-inner">  {{/hasbadge}}
+        {{^hasbadge}} <a class="grid-section-inner" href="{{sectionurl}}"> {{/hasbadge}}
         {{/popup}}
         {{#popup}}
         <div class="grid-modal grid-section-inner d-flex flex-column h-100 justify-content-between" data-toggle="modal" data-target="#gridPopup" data-section="{{number}}" tabindex="0">
@@ -113,19 +109,13 @@
             </div>
             {{/imageerror}}
         {{^popup}}
-        {{#notavailable}}
-        </div>
-        {{/notavailable}}
-        {{^notavailable}}
-        </a>
-        {{/notavailable}}
+        {{#notavailable}}</div>{{/notavailable}}
+        {{^notavailable}}</a>{{/notavailable}}
         {{/popup}}
         {{#popup}}
         </div>
         {{/popup}}
-        {{#hasbadge}}
-        </div>
-        {{/hasbadge}}
+        {{#hasbadge}}</div>{{/hasbadge}}
     </div>
     {{/gridsections}}
 </div>

--- a/templates/grid.mustache
+++ b/templates/grid.mustache
@@ -75,13 +75,13 @@
     {{/sectionbreak}}
     <div id="section-{{number}}" class="grid-section card{{#iscurrent}} currentgridsection{{/iscurrent}}" title="{{sectionname}}">
         {{^popup}}
-        {{#hasbadge}}<div class="grid-section-inner">  {{/hasbadge}}
-        {{^hasbadge}} <a class="grid-section-inner" href="{{sectionurl}}"> {{/hasbadge}}
+        {{#hasbadge}}<div class="grid-section-inner">{{/hasbadge}}
+        {{^hasbadge}}<a class="grid-section-inner" href="{{sectionurl}}">{{/hasbadge}}
         {{/popup}}
         {{#popup}}
         <div class="grid-modal grid-section-inner d-flex flex-column h-100 justify-content-between" data-toggle="modal" data-target="#gridPopup" data-section="{{number}}" tabindex="0">
         {{/popup}}
-            <div class="card-header text-truncate h-100">
+            <div class="card-header text-truncate">
                 <h3 class="h4">{{{sectionname}}}</h3>
                 {{#hasbadge}}
                 <div data-region="sectionbadges" class="sectionbadges d-flex">
@@ -109,13 +109,12 @@
             </div>
             {{/imageerror}}
         {{^popup}}
-        {{#notavailable}}</div>{{/notavailable}}
-        {{^notavailable}}</a>{{/notavailable}}
+        {{#hasbadge}}</div>{{/hasbadge}}
+        {{^hasbadge}}</a>{{/hasbadge}}
         {{/popup}}
         {{#popup}}
         </div>
         {{/popup}}
-        {{#hasbadge}}</div>{{/hasbadge}}
     </div>
     {{/gridsections}}
 </div>


### PR DESCRIPTION
#217 Once you hide a section, the next sections will be displayed below the hidden section because of the missing div in grid.mustache
